### PR TITLE
Disable MiniCssExtractPlugin 'esModule' option on production

### DIFF
--- a/config/webpack/webpack.production.js
+++ b/config/webpack/webpack.production.js
@@ -90,7 +90,12 @@ const productionConfig = {
           {
             test: /\.module\.(less|css)$/,
             use: [
-              MiniCssExtractPlugin.loader,
+              {
+                loader: MiniCssExtractPlugin.loader,
+                options: {
+                  esModule: false,
+                },
+              },
               {
                 loader: "css-loader",
                 options: {


### PR DESCRIPTION
fix #175 